### PR TITLE
Use 100vw width for opacity layer

### DIFF
--- a/public/static/css/layout.css
+++ b/public/static/css/layout.css
@@ -97,7 +97,7 @@ body {
     opacity: 0.5;
     position: fixed;
     top: 0;
-    width: calc(100vw - 20px);
+    width: 100vw;
     z-index: 999;
 }
 


### PR DESCRIPTION
This pull request addresses an issue where the opacity layer wasn't rendered full-screen on mobile web browsers.